### PR TITLE
fixes (#2)

### DIFF
--- a/src/hooks/use-scan-games.ts
+++ b/src/hooks/use-scan-games.ts
@@ -171,9 +171,8 @@ export function useScanGames() {
       setScanProgress(100);
       return result;
     },
-    onSuccess: async () => {
-      // Refresh games data in TanStack DB store
-      await refetch();
+    onSuccess: () => {
+      // The 'games-updated' event will handle the UI update.
       setTimeout(() => setScanProgress(0), 500);
     },
   });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -76,13 +76,10 @@ export async function initializeStore() {
     const gameInfos = await invoke<GameInfo[]>('get_installed_games');
     const games = gameInfos.map(convertGameInfo);
 
-    // Clear any existing games first (in case of re-initialization)
-    // Note: We'll let the collection handle duplicates via upsert behavior
-
-    // Populate games collection with fresh data
-    games.forEach(game => {
+    // Populate games collection with fresh data, assuming upsert behavior
+    for (const game of games) {
       gameCollection.insert(game as any);
-    });
+    }
 
     // Load initial settings
     const settings = await invoke<Settings>('get_settings');
@@ -101,19 +98,15 @@ export async function initializeStore() {
 // Set up real-time event listeners
 function setupRealtimeListeners() {
   // Listen for games updates from backend
-  listen('games-updated', async () => {
+  listen<GameInfo[]>('games-updated', async (event) => {
     try {
-      const gameInfos = await invoke<GameInfo[]>('get_installed_games');
+      const gameInfos = event.payload;
       const games = gameInfos.map(convertGameInfo);
 
-      // Clear existing games first, then insert fresh data
-      // Since we can't easily get all items synchronously, we'll use upsert behavior
-      // The collection will handle duplicates by updating existing items
-      
-      // Insert/update fresh games data
-      games.forEach(game => {
+      // Insert new games, assuming upsert behavior from `insert`
+      for (const game of games) {
         gameCollection.insert(game as any);
-      });
+      }
     } catch (error) {
       console.error('Failed to update games from backend:', error);
     }


### PR DESCRIPTION
* fix(games): clear existing games before inserting fresh data

Ensure proper game data synchronization by clearing existing games before inserting fresh data in useScanGames hook and store initialization. This prevents duplicate entries and maintains data consistency.

* chore: bump version to 0.1.2

* refactor(use-scan-games): optimize game data update after scan

Replace refetch with direct update from scan results to avoid unnecessary network requests and improve performance

* refactor(game-sync): optimize game data synchronization flow

- Replace manual game collection clearing with event-driven updates
- Simplify game insertion logic using upsert behavior
- Handle game updates through 'games-updated' event payload